### PR TITLE
account for mysterious extra quotes in hyperlink

### DIFF
--- a/lib/swordfish/formats/docx/parser.rb
+++ b/lib/swordfish/formats/docx/parser.rb
@@ -53,7 +53,7 @@ module Swordfish
                     if instruction =~ /^\s*HYPERLINK/
                       # A hyperlink
                       complex_field = Swordfish::Node::Hyperlink.new
-                      complex_field.href = instruction.match(/^\s*HYPERLINK (?:\\l )?"([^"]+)"/).captures[0]
+                      complex_field.href = instruction.match(/^\s*HYPERLINK (?:"" )?(?:\\l )?"([^"]+)"/).captures[0]
                     else
                       # Anything else
                       complex_field = Swordfish::Node::Text.new


### PR DESCRIPTION
e.g. HYPERLINK "" \l "hoyle-ch05_s01_f01"
