### PR TITLE
Fix case where normal paragraphs can have an empty numPr for some reason

### DIFF
--- a/lib/swordfish/formats/docx/document.rb
+++ b/lib/swordfish/formats/docx/document.rb
@@ -67,7 +67,9 @@ module Swordfish
         @xml.xpath('//w:body').children.each do |node|
           case node.name
             when 'p'
-              if node.xpath('.//w:numPr').length == 0 && (@buffer.is_a?(Swordfish::Node::List) ? node.xpath('.//w:ind[@w:left]').length.zero? : true)
+              no_numbering_prop = node.xpath('.//w:numPr').length.zero? || node.xpath('.//w:numPr/w:ilvl | .//w:numPr/w:numId').length.zero?
+              not_multiparagraph_list_item = (@buffer.is_a?(Swordfish::Node::List) ? node.xpath('.//w:ind[@w:left]').length.zero? : true)
+              if no_numbering_prop && not_multiparagraph_list_item
                 # Regular paragraph
                 # (The buffer check makes sure that this isn't an indented paragraph immediately after a list item,
                 # which means we're most likely dealing with a multi-paragraph list item)


### PR DESCRIPTION
This was causing normal paragraphs to be interpreted as lists. I'm still not sure _why_ a normal paragraph would have numbering properties present, but not functional...
