### PR TITLE
Create Inline class encompassing Text and Hyperlink for better group behavior

### DIFF
--- a/lib/swordfish/formats/docx/parser.rb
+++ b/lib/swordfish/formats/docx/parser.rb
@@ -127,7 +127,7 @@ module Swordfish
         if node.xpath(".//w:numPr/w:ilvl").length.zero?
           para = Swordfish::Node::Paragraph.new
           _node_parse_runs(node).each {|r| para.append(r)}
-          @buffer.last_list_item(:recurse => true).wrap_children(Swordfish::Node::Text, Swordfish::Node::Paragraph)
+          @buffer.last_list_item(:recurse => true).wrap_children(Swordfish::Node::Inline, Swordfish::Node::Paragraph)
           @buffer.last_list_item(:recurse => true).append para
           return
         end

--- a/lib/swordfish/nodes/base.rb
+++ b/lib/swordfish/nodes/base.rb
@@ -85,6 +85,9 @@ module Swordfish
       end
     end
 
+    class Inline < Base
+    end
+
     class BadContentError < Exception
     end
   end

--- a/lib/swordfish/nodes/hyperlink.rb
+++ b/lib/swordfish/nodes/hyperlink.rb
@@ -2,7 +2,7 @@
 
 module Swordfish
   module Node
-    class Hyperlink < Base
+    class Hyperlink < Inline
 
       attr_accessor :href
 

--- a/lib/swordfish/nodes/text.rb
+++ b/lib/swordfish/nodes/text.rb
@@ -2,7 +2,7 @@
 
 module Swordfish
   module Node
-    class Text < Base
+    class Text < Inline
 
       # Override Base append because a text node should never have children
       def append(node)


### PR DESCRIPTION
This will fix a problem where links would occasionally get pulled outside of paragraphs inside lists.
